### PR TITLE
osx_is_app should cause python.app to be used on macos

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch:     python
-  number:     0
+  number:     1
   script:     python -m pip install --no-deps --ignore-installed .
   osx_is_app: True
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
-  number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  noarch:     python
+  number:     0
+  script:     python -m pip install --no-deps --ignore-installed .
+  osx_is_app: True
   entry_points:
     - render  = fsleyes.render:main
     - fsleyes = fsleyes.main:main


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
