### PR TITLE
MNT: Upcoming 1.3.3 does not depend on pyobjc-*.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,7 @@ requirements:
     - python.app              # [osx]
     - tk !=8.6.9              # [osx]
     - appnope                 # [osx]
-    - pyobjc-core             # [osx]
-    - pyobjc-framework-Cocoa  # [osx]
-    - mesalib 18.*            # [linux]
+    - mesalib                 # [linux]
     - fslpy >=3.6
     - fsleyes-props >=1.7.2
     - fsleyes-widgets >=0.12
@@ -78,12 +76,12 @@ test:
     - fsleyes.plugins
     - fsleyes.profiles
     - fsleyes.views
-#   source_files:
-#     - fsleyes/assets/icons/app_icon.png
+  source_files:
+    - fsleyes/assets/icons/app_icon.png
   commands:
     - fsleyes -V
     - fsleyes -h
-#     - fsleyes render -of out.png fsleyes/assets/icons/app_icon.png  # [osx]
+    - fsleyes render -of out.png fsleyes/assets/icons/app_icon.png  # [osx]
 
 app:
   entry: fsleyes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,7 +81,7 @@ test:
   commands:
     - fsleyes -V
     - fsleyes -h
-    - fsleyes render -of out.png fsleyes/assets/icons/app_icon.png  # [not win]
+    - fsleyes render -of out.png fsleyes/assets/icons/app_icon.png  # [linux]
 
 app:
   entry: fsleyes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,7 +81,7 @@ test:
   commands:
     - fsleyes -V
     - fsleyes -h
-    - fsleyes render -of out.png fsleyes/assets/icons/app_icon.png
+    - fsleyes render -of out.png fsleyes/assets/icons/app_icon.png  # [not win]
 
 app:
   entry: fsleyes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,7 +81,7 @@ test:
   commands:
     - fsleyes -V
     - fsleyes -h
-    - fsleyes render -of out.png fsleyes/assets/icons/app_icon.png  # [osx]
+    - fsleyes render -of out.png fsleyes/assets/icons/app_icon.png
 
 app:
   entry: fsleyes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "fsleyes" %}
-{% set version = "1.3.2" %}
-{% set sha256 = "e9b2bd21aaa16362715d90e1e5021ac89353a340d1d22bcd8d5de02853aff83a" %}
+{% set version = "1.3.3" %}
+{% set sha256 = "cc26ed271c11df48978139a451ce85c9baeaa8765e0dbe33d0407cb0e5bd5d51" %}
 
 package:
   name: {{ name }}
@@ -15,7 +15,7 @@ source:
     - opengl.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<37]
   osx_is_app: true
   entry_points:


### PR DESCRIPTION
DO NOT MERGE YET - version 1.3.3 should be available on PyPI soon.

- Bump to 1.3.3
- Remove pyobjc from requirements list (now interacting with objc runtime directly via `ctypes`)
- Un-pin mesalib, as the upstream issues should be resolved (conda-forge/mesalib-feedstock#16)
- See if sanity check render test is working yet

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
