### PR TITLE
MNT: Remove mesalib, as it interferes with on-screen rendering

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - opengl.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   osx_is_app: true
   entry_points:
@@ -39,9 +39,6 @@ requirements:
     - python.app
     - tk !=8.6.9
     - appnope ==0.1.*
-    {% endif %}
-    {% if noarch_platform == "linux" %}
-    - mesalib
     {% endif %}
     - fslpy >=3.15
     - fsleyes-props >=1.11
@@ -71,6 +68,11 @@ requirements:
     - dcm2niix >=1.0.20181114
 
 test:
+  # need osmesa on linux
+  {% if noarch_platform == "linux" %}
+  requires:
+    - mesalib
+  {% endif %}
   imports:
     - fsleyes
     - fsleyes.actions


### PR DESCRIPTION
1. Some [fairly substantial changes](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/23451/diffs#0cc1139e3347f573ae1feee5b73dbc8a8a21fcfa) have been made to `glapi` in Mesalib 23.2.1 which is has introduced a binary incompatibility, and is causing FSLeyes to crash. This is because ...

2. In some on-screen rendering scenarios, the `libglapi.so` file from [`mesalib`](https://github.com/conda-forge/mesalib-feedstock) is being loaded in preference to the system `libglapi.so`. 

3. FSLeyes depends on `mesalib` purely as a convenience for off-screen rendering. It can easily be manually installed (by conda or at system level) in situations where it is needed.

The main issue here is point 2 - I'm not yet sure of why `$CONDA_PREFIX/lib/libglapi.so` is being loaded in preference to the system `libglapi.so` version

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
