### PR TITLE
MNT: Relax wxpython pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     - opengl.patch
 
 build:
-  number: 2
+  number: 3
   noarch: python
   osx_is_app: true
   entry_points:
@@ -74,7 +74,7 @@ requirements:
     - scipy >=0.18
     - trimesh >=2.37.29
     - rtree >=0.8.3
-    - wxpython >=4.2.2
+    - wxpython >=4
     - xnat >=0.3.3
     - wxnatpy >=0.4.0
     - indexed_gzip >=0.7


### PR DESCRIPTION
Some installs will still  need 4.2.1 (4.2.1/wxwiwdgets 3.2.5 was built against zlib 1.2, whereas 4.2.2/wxwidgets 3.2.6 was built against zlib 1.3)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
