### PR TITLE
Remove python.app from requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     - opengl.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   osx_is_app: true
   entry_points:
@@ -56,7 +56,6 @@ requirements:
     - __{{ noarch_platform }}
     - python >={{ python_min }}
     {% if noarch_platform == "osx" %}
-    - python.app
     - tk !=8.6.9
     - appnope ==0.1.*
     {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,32 +59,32 @@ requirements:
     - tk !=8.6.9
     - appnope ==0.1.*
     {% endif %}
-    - fslpy >=3.22
-    - fsleyes-props >=1.12
-    - fsleyes-widgets >=0.16
+    - dcm2niix >=1.0.20181114
     - file-tree
     - file-tree-fsl
+    - fsleyes-props >=1.13
+    - fsleyes-widgets >=0.17
+    - fslpy >=3.22
+    - indexed_gzip >=0.7
+    - ipykernel >=4.8
+    - ipython >=5
     - jinja2 >=2
+    - jupyter_client >=5.3.1
     - matplotlib-base >=3.5
+    - nbclassic
     - nibabel >=2.3
     - numpy >=1.14
     - pillow >=3.2.0
     - pyopengl >=3.1.0
     - pyparsing >=3
-    - scipy >=0.18
-    - trimesh >=2.37.29
+    - pyzmq >=17
     - rtree >=0.8.3
+    - scipy >=0.18
+    - tornado >=5
+    - trimesh >=2.37.29
+    - wxnatpy >=0.4.0
     - wxpython >=4
     - xnat >=0.3.3
-    - wxnatpy >=0.4.0
-    - indexed_gzip >=0.7
-    - ipykernel >=4.8
-    - ipython >=5
-    - jupyter_client >=5.3.1
-    - nbclassic
-    - pyzmq >=17
-    - tornado >=5
-    - dcm2niix >=1.0.20181114
 
 test:
 


### PR DESCRIPTION
python.app hasn't been needed for some time: https://github.com/conda-forge/python.app-feedstock/issues/32

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
